### PR TITLE
return validation errors

### DIFF
--- a/app/controllers/api/class_years_controller.rb
+++ b/app/controllers/api/class_years_controller.rb
@@ -24,7 +24,7 @@ class Api::ClassYearsController < Api::ApplicationController
 
   def update
     authorize @class_year
-    if @class_year.update(class_year_params)
+    if @class_year.update_attributes(class_year_params)
       render json: @class_year, status: 200
     else
       render json: @class_year, status: 422

--- a/app/controllers/api/semesters_controller.rb
+++ b/app/controllers/api/semesters_controller.rb
@@ -23,7 +23,7 @@ class Api::SemestersController < Api::ApplicationController
 
   def update
     authorize @semester
-    if @semester.update(semester_params)
+    if @semester.update_attributes(semester_params)
       render json: @semester, status: 200
     else
       render json: @semester, status: 422

--- a/app/controllers/api/subjects_controller.rb
+++ b/app/controllers/api/subjects_controller.rb
@@ -23,7 +23,7 @@ class Api::SubjectsController < Api::ApplicationController
 
   def update
     authorize @subject
-    if @subject.update(subject_params)
+    if @subject.update_attributes(subject_params)
       render json: @subject, status: 200
     else
       render json: @subject, status: 422

--- a/app/serializers/class_year_serializer.rb
+++ b/app/serializers/class_year_serializer.rb
@@ -1,0 +1,7 @@
+class ClassYearSerializer < ActiveModel::Serializer
+  attributes :id,
+             :year,
+             :created_at,
+             :updated_at,
+             :errors
+end

--- a/app/serializers/semester_serializer.rb
+++ b/app/serializers/semester_serializer.rb
@@ -4,5 +4,6 @@ class SemesterSerializer < ActiveModel::Serializer
              :identifier,
              :subject_ids,
              :created_at,
-             :updated_at
+             :updated_at,
+             :errors
 end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -1,0 +1,8 @@
+class SubjectSerializer < ActiveModel::Serializer
+  attributes :id,
+             :title_ja,
+             :title_en,
+             :created_at,
+             :updated_at,
+             :errors
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -15,13 +15,7 @@ class UserSerializer < ActiveModel::Serializer
              :email_mobile,
              :admin,
              :class_year_id,
+             :created_at,
+             :updated_at,
              :errors
-
-  def full_name
-    object.full_name
-  end
-
-  def errors
-    object.errors
-  end
 end

--- a/spec/requests/class_years_spec.rb
+++ b/spec/requests/class_years_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe "ClassYears", :type => :request do
       post("/api/class_years", { year: 94 }.to_json)
       expect(response.status).to eq(401)
     end
+
+    it "returns 422 when model validation fails" do
+      admin = create_admin_with_token
+      post_with_token(admin, "/api/class_years", {}.to_json)
+      expect(response.status).to eq(422)
+      expect(json["errors"]["year"]).to include("can't be blank")
+    end
   end
 
   describe "PATCH /api/class_years/1" do
@@ -60,6 +67,15 @@ RSpec.describe "ClassYears", :type => :request do
     it "returns 401 to an unauthorized client" do
       patch("/api/class_years/1", { year: 94 }.to_json)
       expect(response.status).to eq(401)
+    end
+
+    it "returns 422 when model validation fails" do
+      cy = ClassYear.create!(year: 94)
+
+      admin = create_admin_with_token
+      patch_with_token(admin, "/api/class_years/#{cy.id}", { year: 93 }.to_json)
+      expect(response.status).to eq(422)
+      expect(json["errors"]["year"]).to include("has already been taken")
     end
   end
 

--- a/spec/requests/semesters_spec.rb
+++ b/spec/requests/semesters_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe "Semesters", :type => :request do
       post("/api/semesters", { class_year_id: 1, identifier: "2b", subject_ids: [1, 2] }.to_json)
       expect(response.status).to eq(401)
     end
+
+    it "returns 422 when model validation fails" do
+      admin = create_admin_with_token
+      post_with_token(admin, "/api/semesters", {}.to_json)
+      expect(response.status).to eq(422)
+      expect(json["errors"]["identifier"]).to include("can't be blank")
+    end
   end
 
   describe "PATCH /api/semesters/1" do
@@ -80,6 +87,15 @@ RSpec.describe "Semesters", :type => :request do
     it "returns 401 to an unauthorized client" do
       patch("/api/semesters/1", { class_year_id: 1, identifier: "3a", subject_ids: [2, 3] }.to_json)
       expect(response.status).to eq(401)
+    end
+
+    it "returns 422 when model validation fails" do
+      s = Semester.create!(class_year_id: 1, identifier: "2b")
+
+      admin = create_admin_with_token
+      patch_with_token(admin, "/api/semesters/#{s.id}", { identifier: "2a" }.to_json)
+      expect(response.status).to eq(422)
+      expect(json["errors"]["identifier"]).to include("has already been taken")
     end
   end
 

--- a/spec/requests/subjects_spec.rb
+++ b/spec/requests/subjects_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe "Subjects", :type => :request do
       post("/api/subjects", { title_ja: "生理学", title_en: "physiology" }.to_json)
       expect(response.status).to eq(401)
     end
+
+    it "returns 422 when model validation fails" do
+      admin = create_admin_with_token
+      post_with_token(admin, "/api/subjects", {}.to_json)
+      expect(response.status).to eq(422)
+      expect(json["errors"]["title_ja"]).to include("can't be blank")
+    end
   end
 
   describe "PATCH /api/subjects/1" do
@@ -72,6 +79,16 @@ RSpec.describe "Subjects", :type => :request do
     it "returns 401 to an unauthorized client" do
       patch("/api/subjects/1", { title_ja: "生化学", title_en: "biochemistry" }.to_json)
       expect(response.status).to eq(401)
+    end
+
+    it "returns 422 when model validation fails" do
+      s1 = Subject.first
+      s2 = Subject.create!(title_ja: "hoge", title_en: "fuga")
+
+      admin = create_admin_with_token
+      patch_with_token(admin, "/api/subjects/#{s2.id}", { title_ja: s1.title_ja }.to_json)
+      expect(response.status).to eq(422)
+      expect(json["errors"]["title_ja"]).to include("has already been taken")
     end
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe "Users" do
       old_size = User.count
       post("/api/users", @params.to_json)
       expect(response.status).to eq(422)
+      expect(json["errors"]["crypted_password"]).to include("can't be blank")
       expect(User.count).to eq(old_size)
     end
   end


### PR DESCRIPTION
solves #56 

`POST` or `PATCH`でDBエラーが出た場合はエラーの内容を返す。
例：

``` json
{
    "year": 93,
    "errors": {
        "year": [
            "has already been taken"
        ]
    }
}
```

ただし、userをcreateするときにpasswordが入力されなかった場合のみ、attribute nameがpasswordではなくcrypted_passwordになるので注意。
`json["errors"]["crypted_password"] = "can't be blank"`
