### PR TITLE
request to re-send activation instruction

### DIFF
--- a/app/controllers/api/activation_requests_controller.rb
+++ b/app/controllers/api/activation_requests_controller.rb
@@ -3,11 +3,17 @@ class Api::ActivationRequestsController < Api::ApplicationController
 
   def create
     @user = User.find_by(email: params[:email])
-    if @user
+
+    unless @user
+      render json: {}, status: 400
+      return
+    end
+
+    if @user.active?
+      render json: { approval_state: @user.approval_state }, status: 400
+    else
       @user.send_activation_needed_email!
       head 200
-    else
-      head 404
     end
   end
 

--- a/app/controllers/api/activation_requests_controller.rb
+++ b/app/controllers/api/activation_requests_controller.rb
@@ -1,0 +1,19 @@
+class Api::ActivationRequestsController < Api::ApplicationController
+  skip_before_action :require_login_with_token
+
+  def create
+    @user = User.find_by(email: params[:email])
+    if @user
+      @user.send_activation_needed_email!
+      head 200
+    else
+      head 404
+    end
+  end
+
+  private
+
+  def params
+    ActionController::Parameters.new(JSON.parse(request.body.read))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,16 @@
 Rails.application.routes.draw do
   namespace :api do
-    resource  :session,        only: [               :create,          :destroy]
+    resource  :session,            only: [               :create,          :destroy]
 
-    resource  :password_reset, only: [               :create, :update          ]
+    resource  :password_reset,     only: [               :create, :update          ]
 
-    resource  :profile,        only: [        :show,          :update          ] do
-      resource :password,      only: [                        :update          ]
+    resource  :activation_request, only: [               :create                   ]
+
+    resource  :profile,            only: [        :show,          :update          ] do
+      resource :password,          only: [                        :update          ]
     end
 
-    resources :users,          only: [:index, :show, :create,          :destroy] do
+    resources :users,              only: [:index, :show, :create,          :destroy] do
       collection do
         post :activate
       end
@@ -17,11 +19,11 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :class_years,    only: [:index, :show, :create, :update, :destroy]
+    resources :class_years,        only: [:index, :show, :create, :update, :destroy]
 
-    resources :subjects,       only: [:index, :show, :create, :update, :destroy]
+    resources :subjects,           only: [:index, :show, :create, :update, :destroy]
 
-    resources :semesters,      only: [:index, :show, :create, :update, :destroy]
+    resources :semesters,          only: [:index, :show, :create, :update, :destroy]
 
     match "*path" => "application#not_found", via: :all
   end

--- a/spec/requests/activation_requests_spec.rb
+++ b/spec/requests/activation_requests_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "ActivationRequests", type: :request do
+  describe "POST /api/activation_request" do
+    before do
+      @guest = create(:guest, activate: false, approve: false)
+    end
+
+    it "delivers activation instruction", autodoc: true do
+      expect_any_instance_of(User).to receive(:send_activation_needed_email!)
+      post("/api/activation_request", { email: @guest.email }.to_json)
+      expect(response.status).to eq(200)
+    end
+
+    it "returns 404 if user is not found on db", autodoc: true do
+      expect_any_instance_of(User).not_to receive(:send_activation_needed_email!)
+      post("/api/activation_request", { email: "hoge@ec.hokudai.ac.jp" }.to_json)
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/requests/activation_requests_spec.rb
+++ b/spec/requests/activation_requests_spec.rb
@@ -12,10 +12,28 @@ RSpec.describe "ActivationRequests", type: :request do
       expect(response.status).to eq(200)
     end
 
-    it "returns 404 if user is not found on db", autodoc: true do
+    it "returns 400 if user is not found on db", autodoc: true do
       expect_any_instance_of(User).not_to receive(:send_activation_needed_email!)
       post("/api/activation_request", { email: "hoge@ec.hokudai.ac.jp" }.to_json)
-      expect(response.status).to eq(404)
+      expect(response.status).to eq(400)
+      expect(json).to eq({})
+    end
+
+    it "returns 400 if user is already activated", autodoc: true do
+      @guest.activate!
+      expect_any_instance_of(User).not_to receive(:send_activation_needed_email!)
+      post("/api/activation_request", { email: @guest.email }.to_json)
+      expect(response.status).to eq(400)
+      expect(json).to eq({ "approval_state" => "waiting" })
+    end
+
+    it "returns 400 if user is already activated and approved", autodoc: true do
+      @guest.activate!
+      @guest.approve!
+      expect_any_instance_of(User).not_to receive(:send_activation_needed_email!)
+      post("/api/activation_request", { email: @guest.email }.to_json)
+      expect(response.status).to eq(400)
+      expect(json).to eq({ "approval_state" => "approved" })
     end
   end
 end


### PR DESCRIPTION
activationメールを再請求

`POST /api/activation_request'
```json
{
    "email": "admin@ec.hokudai.ac.jp"
}
```

メールアドレスが見つかった時：メール送信、`200`
見つからなかった時：`404`