### PR TITLE
fetch rails-api from upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'rails', '4.2.0'
-gem 'rails-api', github: 'iTakeshi/rails-api', branch: 'rails42'
+gem 'rails-api', github: 'rails-api/rails-api'
 gem 'sqlite3'
 
 gem 'active_model_serializers', github: 'rails-api/active_model_serializers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/iTakeshi/rails-api.git
-  revision: 2bac0bd7bade859d45ebc47b268df180ab7b6eb8
-  branch: rails42
-  specs:
-    rails-api (0.3.1)
-      actionpack (>= 3.2.11)
-      railties (>= 3.2.11)
-
-GIT
   remote: https://github.com/iTakeshi/sorcery.git
   revision: 6035b8f3d5b532b84683126f50f663ecef05ae28
   branch: user_approval
@@ -23,6 +14,14 @@ GIT
   specs:
     active_model_serializers (0.10.0.pre)
       activemodel (>= 4.0)
+
+GIT
+  remote: https://github.com/rails-api/rails-api.git
+  revision: 2e09132e29845180da4f66ac596304ec9cf8c715
+  specs:
+    rails-api (0.3.1)
+      actionpack (>= 3.2.11)
+      railties (>= 3.2.11)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Rails 4.2でDeprecation warningが出ているところをオレオレForkで直して使っていたが、本家できちんと直されたのでupstreamから取得するように変更