### PR TITLE
fix .sass file build

### DIFF
--- a/client/page/admin/user/user.coffee
+++ b/client/page/admin/user/user.coffee
@@ -142,7 +142,7 @@ angular.module modulePage
 
 
 .controller 'AdminUserDetailCtrl',
-    ($scope, $stateParams, Notify) ->
+    ($scope, $state, $stateParams, Notify) ->
         user_id = $stateParams.id
 
         $scope.deleting = false

--- a/client/style/_table.sass
+++ b/client/style/_table.sass
@@ -1,8 +1,8 @@
 .table
-    width: 100%;
-    max-width: 100%;
+    width: 100%
+    max-width: 100%
     border-collapse: collapse
-    margin-bottom: $line-height-computed;
+    margin-bottom: $line-height-computed
 
     td, th
         padding: $table-cell-padding

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -13,6 +13,8 @@ dateFormat = require 'dateformat'
 
 play = require 'play'
 
+
+
 sounds =
     error: 'misc/error.mp3'
 
@@ -84,10 +86,9 @@ g.task 'image', ['clean'], ->
 
 
 g.task 'css:vendor', ['clean'], ->
-    g.src "#{conf.src}/vendor/**/*.{sass,scss}"
+    g.src "#{conf.src}/vendor/**/*.scss"
     .pipe $.sass
         includePaths: [conf.bowerDir]
-        sourceComments: 'normal'
     .on 'error', onError
     .pipe $.autoprefixer()
 
@@ -100,6 +101,7 @@ g.task 'css:common', ['clean'], ->
     g.src "#{conf.src}/style/**/*.sass"
     .pipe $.sass
         sourceComments: 'normal'
+        indentedSyntax: true
     .on 'error', onError
     .pipe $.autoprefixer()
     .pipe g.dest "#{conf.dest}/style/"
@@ -107,7 +109,7 @@ g.task 'css:common', ['clean'], ->
 
 g.task 'css:app:inject', ['clean'], ->
     target = [
-        "#{conf.src}/{page,component}/**/*.{sass,scss}"
+        "#{conf.src}/{page,component}/**/*.sass"
     ]
 
     g.src "#{conf.src}/app.sass"
@@ -128,7 +130,7 @@ g.task 'css:app:inject', ['clean'], ->
 g.task 'css:app', ['clean', 'css:app:inject'], ->
     g.src "#{conf.src}/app.sass"
     .pipe $.sass
-        sourceComments: 'normal'
+        indentedSyntax: true
     .on 'error', onError
     .pipe $.autoprefixer()
     .pipe g.dest "#{conf.dest}/"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/hokui/hokui.net",
   "devDependencies": {
     "coffee-script": "^1.8.0",
-    "date-utils": "^1.2.16",
+    "dateformat": "^1.0.11",
     "del": "^0.1.3",
     "gulp": "^3.8.10",
     "gulp-angular-templatecache": "^1.4.2",
@@ -38,7 +38,7 @@
     "gulp-minify-html": "^0.1.7",
     "gulp-ng-annotate": "^0.3.6",
     "gulp-plumber": "^0.6.6",
-    "gulp-sass": "^1.1.0",
+    "gulp-sass": "^1.3.2",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",


### PR DESCRIPTION
`gulp-sass`で普通に`.sass`ファイルをビルドしようとしても、SCSSの文法でコンパイルされる問題があり、これまでは

```js
sass({sourceComments: 'normal'})
```

という奇妙なオプションで`Libsass`の方にインデントスタイルであると認識させていたが、`Libsass`の方でこの辺りの修正が入って、それに追従して最新の`gulp-sass`では

```js
sass({indentedSyntax: true})
```

というわかりやすいオプションになっていたので、それに対応しました。

「拡張子見てその辺判断しろや」というのは言っちゃいけないんですかね。あとDateのformatするやつも依存に追加しておきました。とりあえずこれで#99 は解決です。
