### PR TITLE
Mod api documents

### DIFF
--- a/app/controllers/api/document_files_controller.rb
+++ b/app/controllers/api/document_files_controller.rb
@@ -50,8 +50,8 @@ class Api::DocumentFilesController < Api::ApplicationController
   private
 
   def find_or_create_document
-    # NOTE this before_action might return Document and prevent original action
-    # from returning DocumentFile
+    # NOTE this before_action might return an instance of Document and prevent
+    # original action from returning a instance of DocumentFile
     @document = Document.where(
       subject_id: document_params[:subject_id],
       class_year: document_params[:class_year],

--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -4,8 +4,7 @@ class Api::DocumentsController < Api::ApplicationController
   # but not
   #   /api/documents
 
-  before_action :set_document, only: [:show, :update, :destroy]
-  after_action :verify_authorized, except: [:index, :show]
+  before_action :set_document, only: :show
 
   def index
     @documents = if params[:code]
@@ -22,35 +21,11 @@ class Api::DocumentsController < Api::ApplicationController
     render json: @document
   end
 
-  def update
-    authorize @document
-    if @document.update_attributes(document_params)
-      render json: @document, status: 200
-    else
-      render json: @document, status: 422
-    end
-  end
-
-  def destroy
-    authorize @document
-    @document.destroy
-    head 200
-  end
-
   private
 
   def set_document
     @document = Subject.find(params[:subject_id]).documents.find(params[:id])
   rescue
     head 404
-  end
-
-  def document_params
-    ActionController::Parameters.new(JSON.parse(request.body.read)).
-      permit(
-        :subject_id,
-        :class_year,
-        :code
-    )
   end
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -1,9 +1,0 @@
-class DocumentPolicy < Struct.new(:user, :document)
-  def update?
-    user.admin?
-  end
-
-  def destroy?
-    user.admin?
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     resources :class_years,        only: [:index, :show, :create, :update, :destroy]
 
     resources :subjects,           only: [:index, :show, :create, :update, :destroy] do
-      resources :documents,        only: [:index, :show,          :update, :destroy] do
+      resources :documents,        only: [:index, :show                            ] do
         resources :document_files, only: [:index                                   ]
       end
     end

--- a/spec/requests/api/documents_spec.rb
+++ b/spec/requests/api/documents_spec.rb
@@ -57,48 +57,5 @@ RSpec.describe "Documents", type: :request do
       expect(response.status).to eq(401)
     end
   end
-
-  describe "PATCH /api/subjects/1/documents/1" do
-    before(:all) do
-      @params = {
-        subject_id: 3,
-        class_year: 95,
-        code: 99
-      }
-    end
-
-    it "updates document parameters", autodoc: true do
-      patch_with_token(@admin, "/api/subjects/#{@doc2.subject_id}/documents/#{@doc2.id}", @params.to_json)
-      expect(response.status).to eq(200)
-      expect(json["code"]).to eq(99)
-    end
-
-    it "returns 403 to a guest" do
-      patch_with_token(@guest, "/api/subjects/#{@doc1.subject_id}/documents/#{@doc1.id}", @params.to_json)
-      expect(response.status).to eq(403)
-    end
-
-    it "returns 401 to an unauthorized client" do
-      patch("/api/subjects/#{@doc1.subject_id}/documents/#{@doc1.id}", @params.to_json)
-      expect(response.status).to eq(401)
-    end
-  end
-
-  describe "DELETE /api/subjects/1/documents/1" do
-    it "destroys the document", autodoc: true do
-      delete_with_token(@admin, "/api/subjects/#{@doc1.subject_id}/documents/#{@doc1.id}")
-      expect(response.status).to eq(200)
-    end
-
-    it "returns 403 to a guest" do
-      delete_with_token(@guest, "/api/subjects/#{@doc1.subject_id}/documents/#{@doc1.id}")
-      expect(response.status).to eq(403)
-    end
-
-    it "returns 401 to an unauthorized client" do
-      delete("/api/subjects/#{@doc1.subject_id}/documents/#{@doc1.id}")
-      expect(response.status).to eq(401)
-    end
-  end
 end
 


### PR DESCRIPTION
In relation to #111

`DocumentsController`から`update`と`destroy`を削除しました。
したがって、`DocumentsController`に存在するアクションは`index`と`show`だけです。

これに伴って、https://github.com/hokui/hokui.net/pull/111#issuecomment-76346790 の件は自動的に解決します。

変更理由：
ユーザーから見た時のアップロード・更新操作はあくまでも`DocumentFile`に対して行われるべきもので、`Document`を明示的に操作できるようにすると混乱を招くおそれがあるため。
#111 の段階で、`DocumentFile`に対して既存のものと異なる`subject_id`を渡して`update`を試みると
新しい`Document`を生成してそれにひもづけるような実装になっていたため、それで十分と判断しました。